### PR TITLE
Update pre-commit hooks and ruff lint configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,14 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.3.4
     hooks:
       - id: ruff
         args: [--fix]
-
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         files: "^src/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,15 @@ matrix.pydantic.extra-dependencies = [
 [tool.ruff]
 line-length = 88
 target-version = "py38"
-# https://beta.ruff.rs/docs/rules/
+
+[tool.ruff.lint]
+pydocstyle = { convention = "numpy" }
 select = [
     "E",    # style errors
     "W",    # style warnings
     "F",    # flakes
     "D",    # pydocstyle
+    "D417", # Missing argument descriptions in the docstring
     "I",    # isort
     "UP",   # pyupgrade
     "B",    # flake8-bugbear
@@ -88,23 +91,12 @@ select = [
     "TCH",  # typecheck
     "TID",  # tidy imports
 ]
-# I do this to get numpy-style docstrings AND retain
-# D417 (Missing argument descriptions in the docstring)
-# otherwise, see:
-# https://beta.ruff.rs/docs/faq/#does-ruff-support-numpy-or-google-style-docstrings
-# https://github.com/charliermarsh/ruff/issues/2606
 ignore = [
     "D100", # Missing docstring in public module
-    "D107", # Missing docstring in __init__
-    "D203", # 1 blank line required before class docstring
-    "D212", # Multi-line docstring summary should start at the first line
-    "D213", # Multi-line docstring summary should start at the second line
     "D401", # First line should be in imperative mood
-    "D413", # Missing blank line after last section
-    "D416", # Section name should end with a colon
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["D", "S"]
 "setup.py" = ["D"]
 
@@ -138,7 +130,5 @@ show_missing = true
 source = ["fieldz"]
 
 # https://github.com/mgedmin/check-manifest#configuration
-# add files that you want check-manifest to explicitly ignore here
-# (files that are in the repo but shouldn't go in the package)
 [tool.check-manifest]
 ignore = [".pre-commit-config.yaml", "tests/**/*"]

--- a/x.py
+++ b/x.py
@@ -1,6 +1,0 @@
-from dataclass_compat import fields
-from ome_types.model import Pixels
-from rich import print
-
-f = {f.name: f for f in fields(Pixels)}
-print(f["id"])


### PR DESCRIPTION
This pull request updates the pre-commit hooks and ruff lint configuration. It includes the following changes:

- Updated ruff-pre-commit to version v0.3.4

- Added ruff-format hook to the ruff-pre-commit configuration

- Updated mirrors-mypy to version v1.9.0

- Updated the ruff lint configuration to include the "D417" rule for missing argument descriptions in docstrings

- Removed unnecessary ignore rules from the ruff lint configuration

- Removed unused code from a Python file

Please review the changes and merge them if they look good.