### PR TITLE
Fix for pydantic 1.X

### DIFF
--- a/src/fieldz/adapters/_pydantic.py
+++ b/src/fieldz/adapters/_pydantic.py
@@ -75,7 +75,7 @@ def _fields_v1(obj: pydantic.BaseModel | type[pydantic.BaseModel]) -> Iterator[F
     except ImportError:
         from pydantic.fields import Undefined  # type: ignore
 
-    annotations = getattr(obj, "__annotations__", {})
+    annotations = {key: field.annotation for key, field in obj.__fields__.items()}
     for name, modelfield in obj.__fields__.items():  # type: ignore
         factory = (
             modelfield.default_factory

--- a/src/fieldz/adapters/_pydantic.py
+++ b/src/fieldz/adapters/_pydantic.py
@@ -107,6 +107,8 @@ def _fields_v1(obj: pydantic.BaseModel | type[pydantic.BaseModel]) -> Iterator[F
 
 def _constraints_v1(modelfield: Any) -> Constraints | None:
     kwargs = {}
+    if not hasattr(modelfield.type_, "__mro__"):
+        return None
     # check if the type is a pydantic constrained type
     for subt in modelfield.type_.__mro__:
         if (subt.__module__ or "").startswith("pydantic.types"):

--- a/src/fieldz/adapters/_pydantic.py
+++ b/src/fieldz/adapters/_pydantic.py
@@ -30,8 +30,9 @@ def is_pydantic_model(obj: object) -> TypeGuard[pydantic.BaseModel]: ...
 def is_pydantic_model(obj: Any) -> bool:
     """Return True if obj is a pydantic.BaseModel subclass or instance."""
     pydantic = sys.modules.get("pydantic", None)
+    pydantic_v1 = sys.modules.get("pydantic.v1", None)
     cls = obj if isinstance(obj, type) else type(obj)
-    if pydantic is not None and issubclass(cls, pydantic.BaseModel):
+    if pydantic is not None and issubclass(cls, (pydantic.BaseModel, pydantic_v1.BaseModel)):
         return True
     elif hasattr(cls, "__pydantic_model__") or hasattr(cls, "__pydantic_fields__"):
         return True
@@ -67,7 +68,10 @@ def replace(obj: pydantic.BaseModel, /, **changes: Any) -> Any:
 
 
 def _fields_v1(obj: pydantic.BaseModel | type[pydantic.BaseModel]) -> Iterator[Field]:
-    from pydantic.fields import Undefined  # type: ignore
+    try:
+        from pydantic.v1.fields import Undefined
+    except ImportError:
+        from pydantic.fields import Undefined # type: ignore
 
     annotations = getattr(obj, "__annotations__", {})
     for name, modelfield in obj.__fields__.items():  # type: ignore

--- a/src/fieldz/adapters/_pydantic.py
+++ b/src/fieldz/adapters/_pydantic.py
@@ -32,9 +32,9 @@ def is_pydantic_model(obj: Any) -> bool:
     pydantic = sys.modules.get("pydantic", None)
     pydantic_v1 = sys.modules.get("pydantic.v1", None)
     cls = obj if isinstance(obj, type) else type(obj)
-    if pydantic is not None and issubclass(
-        cls, (pydantic.BaseModel, pydantic_v1.BaseModel)
-    ):
+    if pydantic is not None and issubclass(cls, pydantic.BaseModel):
+        return True
+    elif pydantic_v1 is not None and issubclass(cls, pydantic_v1.BaseModel):
         return True
     elif hasattr(cls, "__pydantic_model__") or hasattr(cls, "__pydantic_fields__"):
         return True

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -13,7 +13,7 @@ def _dataclass_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = dataclasses.field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -25,7 +25,7 @@ def _named_tuple() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = []  # noqa
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -38,7 +38,7 @@ def _pydantic_v1_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = Field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -51,7 +51,7 @@ def _pydantic_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = Field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -66,7 +66,7 @@ def _pydantic_dataclass() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = dataclasses.field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -81,7 +81,7 @@ def _sqlmodel() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = Field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -96,7 +96,7 @@ def _attrs_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = attr.field(default=attr.Factory(list))
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -110,7 +110,7 @@ def _msgspec_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = msgspec.field(default_factory=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -125,7 +125,7 @@ def _dataclassy_model() -> type:
         c: float = 0.0
         d: bool = False
         e: List[int] = []  # noqa
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -139,7 +139,7 @@ def _django_model() -> type:
         c: float = models.FloatField(default=0.0)
         d: bool = models.BooleanField(default=False)
         e: List[int] = models.JSONField(default=list)
-        f: Any = tuple()
+        f: Any = ()
 
     return Model
 
@@ -150,7 +150,7 @@ def _django_model() -> type:
         _dataclass_model,
         _named_tuple,
         _dataclassy_model,
-        _pydantic_v1_model,
+        _pydantic_model,
         _pydantic_model,
         _attrs_model,
         _msgspec_model,
@@ -162,14 +162,14 @@ def _django_model() -> type:
 def test_adapters(builder: Callable) -> None:
     model = builder()
     obj = model()
-    assert asdict(obj) == {"a": 0, "b": None, "c": 0.0, "d": False, "e": [], "f": tuple()}
-    assert astuple(obj) == (0, None, 0.0, False, [], tuple())
+    assert asdict(obj) == {"a": 0, "b": None, "c": 0.0, "d": False, "e": [], "f": ()}
+    assert astuple(obj) == (0, None, 0.0, False, [], ())
     fields_ = fields(obj)
     assert [f.name for f in fields_] == ["a", "b", "c", "d", "e", "f"]
     assert [f.type for f in fields_] == [int, Optional[str], float, bool, List[int], Any]
     assert [f.frozen for f in fields_] == [False] * 6
     if is_named_tuple(obj):
-        assert [f.default for f in fields_] == [0, None, 0.0, False, [], tuple()]
+        assert [f.default for f in fields_] == [0, None, 0.0, False, [], ()]
     else:
         # namedtuples don't have default_factory
         assert [f.default for f in fields_] == [
@@ -178,7 +178,7 @@ def test_adapters(builder: Callable) -> None:
             0.0,
             False,
             Field.MISSING,
-            tuple()
+            ()
         ]
         assert [f.default_factory for f in fields_] == [
             *[Field.MISSING] * 4,
@@ -186,8 +186,8 @@ def test_adapters(builder: Callable) -> None:
             Field.MISSING
         ]
 
-    obj2 = replace(obj, a=1, b="b2", c=1.0, d=True, e=[1, 2, 3], f=dict())
-    assert asdict(obj2) == {"a": 1, "b": "b2", "c": 1.0, "d": True, "e": [1, 2, 3], "f": dict()}
+    obj2 = replace(obj, a=1, b="b2", c=1.0, d=True, e=[1, 2, 3], f={})
+    assert asdict(obj2) == {"a": 1, "b": "b2", "c": 1.0, "d": True, "e": [1, 2, 3], "f": {}}
 
     p = params(obj)
     assert p.eq is True

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -154,7 +154,7 @@ def _django_model() -> type:
         _named_tuple,
         _dataclassy_model,
         _pydantic_model,
-        _pydantic_model,
+        _pydantic_v1_model,
         _attrs_model,
         _msgspec_model,
         _sqlmodel,

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -182,14 +182,7 @@ def test_adapters(builder: Callable) -> None:
         assert [f.default for f in fields_] == [0, None, 0.0, False, [], ()]
     else:
         # namedtuples don't have default_factory
-        assert [f.default for f in fields_] == [
-            0,
-            None,
-            0.0,
-            False,
-            Field.MISSING,
-            ()
-        ]
+        assert [f.default for f in fields_] == [0, None, 0.0, False, Field.MISSING, ()]
         assert [f.default_factory for f in fields_] == [
             *[Field.MISSING] * 4,
             list,
@@ -197,7 +190,14 @@ def test_adapters(builder: Callable) -> None:
         ]
 
     obj2 = replace(obj, a=1, b="b2", c=1.0, d=True, e=[1, 2, 3], f={})
-    assert asdict(obj2) == {"a": 1, "b": "b2", "c": 1.0, "d": True, "e": [1, 2, 3], "f": {}}
+    assert asdict(obj2) == {
+        "a": 1,
+        "b": "b2",
+        "c": 1.0,
+        "d": True,
+        "e": [1, 2, 3],
+        "f": {},
+    }
 
     p = params(obj)
     assert p.eq is True

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -30,6 +30,18 @@ def _named_tuple() -> type:
 
     return Model
 
+def _pydantic_v1_model_str() -> type:
+    from pydantic.v1 import BaseModel, Field
+
+    class Model(BaseModel):
+        a: "int" = 0
+        b: "Optional[str]" = None
+        c: "float" = 0.0
+        d: "bool" = False
+        e: "List[int]" = Field(default_factory=list)
+        f: "Any" = ()
+
+    return Model
 
 def _pydantic_v1_model() -> type:
     from pydantic.v1 import BaseModel, Field
@@ -155,6 +167,7 @@ def _django_model() -> type:
         _dataclassy_model,
         _pydantic_model,
         _pydantic_v1_model,
+        _pydantic_v1_model_str,
         _attrs_model,
         _msgspec_model,
         _sqlmodel,

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -30,6 +30,7 @@ def _named_tuple() -> type:
 
     return Model
 
+
 def _pydantic_v1_model_str() -> type:
     from pydantic.v1 import BaseModel, Field
 
@@ -42,6 +43,7 @@ def _pydantic_v1_model_str() -> type:
         f: "Any" = ()
 
     return Model
+
 
 def _pydantic_v1_model() -> type:
     from pydantic.v1 import BaseModel, Field

--- a/tests/test_fieldz.py
+++ b/tests/test_fieldz.py
@@ -165,20 +165,8 @@ def _django_model() -> type:
 def test_adapters(builder: Callable) -> None:
     model = builder()
     obj = model()
-<<<<<<< HEAD
     assert asdict(obj) == {"a": 0, "b": None, "c": 0.0, "d": False, "e": [], "f": ()}
     assert astuple(obj) == (0, None, 0.0, False, [], ())
-=======
-    assert asdict(obj) == {
-        "a": 0,
-        "b": None,
-        "c": 0.0,
-        "d": False,
-        "e": [],
-        "f": tuple(),
-    }
-    assert astuple(obj) == (0, None, 0.0, False, [], tuple())
->>>>>>> 214743a3a168d48baa7f1d2551f26409684904ed
     fields_ = fields(obj)
     assert [f.name for f in fields_] == ["a", "b", "c", "d", "e", "f"]
     assert [f.type for f in fields_] == [
@@ -208,20 +196,8 @@ def test_adapters(builder: Callable) -> None:
             Field.MISSING,
         ]
 
-<<<<<<< HEAD
     obj2 = replace(obj, a=1, b="b2", c=1.0, d=True, e=[1, 2, 3], f={})
     assert asdict(obj2) == {"a": 1, "b": "b2", "c": 1.0, "d": True, "e": [1, 2, 3], "f": {}}
-=======
-    obj2 = replace(obj, a=1, b="b2", c=1.0, d=True, e=[1, 2, 3], f=dict())
-    assert asdict(obj2) == {
-        "a": 1,
-        "b": "b2",
-        "c": 1.0,
-        "d": True,
-        "e": [1, 2, 3],
-        "f": dict(),
-    }
->>>>>>> 214743a3a168d48baa7f1d2551f26409684904ed
 
     p = params(obj)
     assert p.eq is True


### PR DESCRIPTION
Fixes #23.

Also fixes another issue I just noticed: delayed annotations such as: `a: "int"` were being treated as `str` by griffe, but I've fixed this also with a test.