### PR TITLE
Use next-generation API for attrs example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ class SomePydanticModel(pydantic.BaseModel):
 ### [`attrs.define`](https://www.attrs.org/en/stable/overview.html)
 
 ```python
-import attr
+import attrs
 
-@attr.define
+@attrs.define
 class SomeAttrsModel:
     a: int = 0
     b: str = "b"
-    c: list[int] = attr.field(default=attr.Factory(list))
+    c: list[int] = attrs.field(factory=list)
 ```
 
 ### [`msgspec.Struct`](https://jcristharif.com/msgspec/)


### PR DESCRIPTION
This PR updates the `attrs` syntax in the README example to the new API.