### PR TITLE
fix: handle the representation of some typing generics and syntatic sugar

### DIFF
--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -96,14 +96,14 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     else:
         # We remove the NewType check because it doesn't work in isinstance prior to python 3.10
         if not isinstance(
-                obj,
-                (
-                        typing_base,
-                        WithArgsTypes,
-                        type,
-                        TypeAliasType,
-                        typing.TypeVar,
-                ),
+            obj,
+            (
+                typing_base,
+                WithArgsTypes,
+                type,
+                TypeAliasType,
+                typing.TypeVar,
+            ),
         ):
             obj = obj.__class__
 

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -68,37 +68,48 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     Takes some logic from `typing._type_repr`.
     """
     if isinstance(obj, types.FunctionType):
+        # In python < 3.10, NewType was a function with __supertype__ set to the wrapped type,
+        # so NewTypes pass through here
         return obj.__name__
     elif obj is ...:
         return "..."
     elif obj in (None, type(None)):
         return "None"
 
-    if not isinstance(
-        obj,
-        (
-            typing_base,
-            WithArgsTypes,
-            type,
-            TypeAliasType,
-            typing.TypeVar,
-            typing.NewType,
-        ),
-    ):
-        obj = obj.__class__
-
-    if isinstance(obj, typing.TypeVar):
-        # TypeVar repr includes a prepended ~, so we use __name__ to get a clean name
-        return obj.__name__
-
     if sys.version_info >= (3, 10):
+        if not isinstance(
+            obj,
+            (
+                typing_base,
+                WithArgsTypes,
+                type,
+                TypeAliasType,
+                typing.TypeVar,
+                typing.NewType,
+            ),
+        ):
+            obj = obj.__class__
+
         if isinstance(obj, typing.NewType):
             # NewType repr includes the module name prepended, so we use __name__ to get a clean name
             return obj.__name__
     else:
-        # In python < 3.10, NewType was a function with __supertype__ set to the wrapped type
-        if callable(obj) and hasattr(obj, "__supertype__"):
-            return obj.__name__
+        # We remove the NewType check because it doesn't work in isinstance prior to python 3.10
+        if not isinstance(
+                obj,
+                (
+                        typing_base,
+                        WithArgsTypes,
+                        type,
+                        TypeAliasType,
+                        typing.TypeVar,
+                ),
+        ):
+            obj = obj.__class__
+
+    if isinstance(obj, typing.TypeVar):
+        # TypeVar repr includes a prepended ~, so we use __name__ to get a clean name
+        return obj.__name__
 
     origin = typing_extensions.get_origin(obj)
     if origin_is_literal(origin):

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -20,6 +20,12 @@ if sys.version_info < (3, 9):
 else:
     from typing import GenericAlias as TypingGenericAlias  # type: ignore
 
+if sys.version_info < (3, 12):
+    # python < 3.12 does not have TypeAliasType
+    TypeAliasType = ()
+else:
+    from typing import TypeAliasType  # type: ignore
+
 if sys.version_info < (3, 10):
 
     def origin_is_union(tp: type[Any] | None) -> bool:
@@ -68,8 +74,13 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     elif obj in (None, type(None)):
         return "None"
 
-    if not isinstance(obj, (typing_base, WithArgsTypes, type)):
+    if not isinstance(obj, (typing_base, WithArgsTypes, type, TypeAliasType, typing.TypeVar, typing.NewType)):
         obj = obj.__class__
+
+    if isinstance(obj, (typing.NewType, typing.TypeVar)):
+        # TypeVar repr includes a prepended ~ and NewType repr includes the module name prepended,
+        # so we use __name__ to get a clean name
+        return obj.__name__
 
     origin = typing_extensions.get_origin(obj)
     if origin_is_literal(origin):

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -91,12 +91,15 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
             obj = obj.__class__
 
         if isinstance(obj, typing.NewType):
-            # NewType repr includes the module name prepended, so we use __name__ to get a clean name
-            # NOTE: ignoring attr-defined because NewType has __name__ but mypy can't see it for some reason;
-            # ignoring no-any-return because we know __name__ must return a string
+            # NewType repr includes the module name prepended, so we use __name__
+            # to get a clean name
+            # NOTE: ignoring attr-defined because NewType has __name__ but mypy
+            # can't see it for some reason; ignoring no-any-return because we
+            # know __name__ must return a string
             return obj.__name__  # type: ignore[attr-defined, no-any-return]
     else:
-        # We remove the NewType check because it doesn't work in isinstance prior to python 3.10
+        # We remove the NewType check because it doesn't work in isinstance prior to
+        # python 3.10
         if not isinstance(
             obj,
             (

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -74,7 +74,17 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     elif obj in (None, type(None)):
         return "None"
 
-    if not isinstance(obj, (typing_base, WithArgsTypes, type, TypeAliasType, typing.TypeVar, typing.NewType)):
+    if not isinstance(
+        obj,
+        (
+            typing_base,
+            WithArgsTypes,
+            type,
+            TypeAliasType,
+            typing.TypeVar,
+            typing.NewType,
+        ),
+    ):
         obj = obj.__class__
 
     if isinstance(obj, (typing.NewType, typing.TypeVar)):

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -24,7 +24,7 @@ if sys.version_info < (3, 12):
     # python < 3.12 does not have TypeAliasType
     TypeAliasType = ()
 else:
-    from typing import TypeAliasType  # type: ignore
+    from typing import TypeAliasType
 
 if sys.version_info < (3, 10):
 
@@ -68,8 +68,8 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     Takes some logic from `typing._type_repr`.
     """
     if isinstance(obj, types.FunctionType):
-        # In python < 3.10, NewType was a function with __supertype__ set to the wrapped type,
-        # so NewTypes pass through here
+        # In python < 3.10, NewType was a function with __supertype__ set to the
+        # wrapped type, so NewTypes pass through here
         return obj.__name__
     elif obj is ...:
         return "..."
@@ -92,7 +92,9 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
 
         if isinstance(obj, typing.NewType):
             # NewType repr includes the module name prepended, so we use __name__ to get a clean name
-            return obj.__name__
+            # NOTE: ignoring attr-defined because NewType has __name__ but mypy can't see it for some reason;
+            # ignoring no-any-return because we know __name__ must return a string
+            return obj.__name__  # type: ignore[attr-defined, no-any-return]
     else:
         # We remove the NewType check because it doesn't work in isinstance prior to python 3.10
         if not isinstance(

--- a/src/fieldz/_repr.py
+++ b/src/fieldz/_repr.py
@@ -87,10 +87,18 @@ def display_as_type(obj: Any, *, modern_union: bool = False) -> str:
     ):
         obj = obj.__class__
 
-    if isinstance(obj, (typing.NewType, typing.TypeVar)):
-        # TypeVar repr includes a prepended ~ and NewType repr includes the module name prepended,
-        # so we use __name__ to get a clean name
+    if isinstance(obj, typing.TypeVar):
+        # TypeVar repr includes a prepended ~, so we use __name__ to get a clean name
         return obj.__name__
+
+    if sys.version_info >= (3, 10):
+        if isinstance(obj, typing.NewType):
+            # NewType repr includes the module name prepended, so we use __name__ to get a clean name
+            return obj.__name__
+    else:
+        # In python < 3.10, NewType was a function with __supertype__ set to the wrapped type
+        if callable(obj) and hasattr(obj, "__supertype__"):
+            return obj.__name__
 
     origin = typing_extensions.get_origin(obj)
     if origin_is_literal(origin):

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,11 +1,15 @@
-from typing import Any, Generic, Literal, Optional, TypeVar, Union
+import sys
+from typing import Any, Generic, Literal, Optional, TypeVar, Union, NewType, TypeAlias
 
+import pytest
 from typing_extensions import Annotated
 
 import fieldz
 from fieldz._repr import PlainRepr
 
 T = TypeVar("T")
+
+NewInt = NewType("NewInt", int)
 
 
 def func() -> None:
@@ -36,6 +40,24 @@ def test_PlainRepr() -> None:
     assert "ParamFoo[int]" in PlainRepr.for_type(ParamFoo[int])
     assert PlainRepr.for_type(Any) == "Any"
     assert PlainRepr.for_type(Annotated[int, None]) == "Annotated[int, None]"
+
+    # test TypeVar and NewInt cases directly as their representation must be handled separately
+    assert PlainRepr.for_type(T) == "T"
+    assert PlainRepr.for_type(NewInt) == "NewInt"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="requires Python 3.12 or newer to support typing syntactic sugar")
+def test_PlainRepr_with_syntactic_sugar() -> None:
+    # Test cases using the typing syntactic sugar of python >= 3.12
+
+    type ExampleAlias = str | int
+    assert PlainRepr.for_type(ExampleAlias) == "ExampleAlias"
+    assert PlainRepr.for_type(
+        ExampleAlias | tuple[ExampleAlias, ...]) == "Union[ExampleAlias, tuple[ExampleAlias, ...]]"
+    assert PlainRepr.for_type(ExampleAlias | tuple[ExampleAlias, ...],
+                              modern_union=True) == "ExampleAlias | tuple[ExampleAlias, ...]"
+    assert PlainRepr.for_type(Annotated[ExampleAlias, None]) == "Annotated[ExampleAlias, None]"
+    assert PlainRepr.for_type(dict[str, ExampleAlias]) == "dict[str, ExampleAlias]"
 
 
 def test_rich_reprs() -> None:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -53,7 +53,10 @@ def test_PlainRepr() -> None:
 def test_PlainRepr_with_syntactic_sugar() -> None:
     # Test cases using the typing syntactic sugar of python >= 3.12
 
-    type ExampleAlias = str | int
+    # Create a namespace dictionary to capture the exec'd variables
+    namespace = {}
+    exec("type ExampleAlias = str | int", namespace)
+    ExampleAlias = namespace["ExampleAlias"]
     assert PlainRepr.for_type(ExampleAlias) == "ExampleAlias"
     assert (
         PlainRepr.for_type(ExampleAlias | tuple[ExampleAlias, ...])

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -41,7 +41,8 @@ def test_PlainRepr() -> None:
     assert PlainRepr.for_type(Any) == "Any"
     assert PlainRepr.for_type(Annotated[int, None]) == "Annotated[int, None]"
 
-    # test TypeVar and NewInt cases directly as their representation must be handled separately
+    # test TypeVar and NewInt cases directly as their representation must be handled
+    # separately
     assert PlainRepr.for_type(T) == "T"
     assert PlainRepr.for_type(NewInt) == "NewInt"
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Generic, Literal, Optional, TypeVar, Union, NewType, TypeAlias
+from typing import Any, Generic, Literal, NewType, Optional, TypeVar, Union
 
 import pytest
 from typing_extensions import Annotated
@@ -46,17 +46,27 @@ def test_PlainRepr() -> None:
     assert PlainRepr.for_type(NewInt) == "NewInt"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="requires Python 3.12 or newer to support typing syntactic sugar")
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="requires Python 3.12 or newer to support typing syntactic sugar",
+)
 def test_PlainRepr_with_syntactic_sugar() -> None:
     # Test cases using the typing syntactic sugar of python >= 3.12
 
     type ExampleAlias = str | int
     assert PlainRepr.for_type(ExampleAlias) == "ExampleAlias"
-    assert PlainRepr.for_type(
-        ExampleAlias | tuple[ExampleAlias, ...]) == "Union[ExampleAlias, tuple[ExampleAlias, ...]]"
-    assert PlainRepr.for_type(ExampleAlias | tuple[ExampleAlias, ...],
-                              modern_union=True) == "ExampleAlias | tuple[ExampleAlias, ...]"
-    assert PlainRepr.for_type(Annotated[ExampleAlias, None]) == "Annotated[ExampleAlias, None]"
+    assert (
+        PlainRepr.for_type(ExampleAlias | tuple[ExampleAlias, ...])
+        == "Union[ExampleAlias, tuple[ExampleAlias, ...]]"
+    )
+    assert (
+        PlainRepr.for_type(ExampleAlias | tuple[ExampleAlias, ...], modern_union=True)
+        == "ExampleAlias | tuple[ExampleAlias, ...]"
+    )
+    assert (
+        PlainRepr.for_type(Annotated[ExampleAlias, None])
+        == "Annotated[ExampleAlias, None]"
+    )
     assert PlainRepr.for_type(dict[str, ExampleAlias]) == "dict[str, ExampleAlias]"
 
 


### PR DESCRIPTION
This fixes the issues in #36 

I have handled the TypeAliasType behind checks for python 3.12 or greater.